### PR TITLE
chore: update nyc dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -903,34 +903,65 @@
       "dev": true
     },
     "nyc": {
-      "version": "6.6.1",
-      "resolved": "http://registry.npmjs.org/nyc/-/nyc-6.6.1.tgz",
-      "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
+      "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0",
+        "archy": "^1.0.0",
         "arrify": "^1.0.1",
         "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.1.2",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
         "default-require-extensions": "^1.0.0",
         "find-cache-dir": "^0.1.1",
-        "find-up": "^1.1.2",
-        "foreground-child": "^1.5.1",
-        "glob": "^7.0.3",
-        "istanbul": "^0.4.3",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.2",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.10.0",
+        "istanbul-lib-report": "^1.1.3",
+        "istanbul-lib-source-maps": "^1.2.3",
+        "istanbul-reports": "^1.4.0",
         "md5-hex": "^1.2.0",
-        "micromatch": "^2.3.7",
+        "merge-source-map": "^1.1.0",
+        "micromatch": "^3.1.10",
         "mkdirp": "^0.5.0",
-        "pkg-up": "^1.0.0",
         "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.0",
-        "signal-exit": "^3.0.0",
-        "source-map": "^0.5.3",
-        "spawn-wrap": "^1.2.2",
-        "test-exclude": "^1.1.0",
-        "yargs": "^4.7.0"
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.2.0",
+        "yargs": "11.1.0",
+        "yargs-parser": "^8.0.0"
       },
       "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
@@ -939,10 +970,265 @@
             "default-require-extensions": "^1.0.0"
           }
         },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
         "arrify": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "caching-transform": {
           "version": "1.0.1",
@@ -952,39 +1238,154 @@
             "md5-hex": "^1.2.0",
             "mkdirp": "^0.5.1",
             "write-file-atomic": "^1.1.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
-            "write-file-atomic": {
-              "version": "1.1.4",
+            "define-property": {
+              "version": "0.2.5",
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
-              },
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.4",
-                  "bundled": true,
-                  "dev": true
-                },
-                "imurmurhash": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true
-                },
-                "slide": {
-                  "version": "1.1.6",
-                  "bundled": true,
-                  "dev": true
-                }
+                "is-descriptor": "^0.1.0"
               }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
             }
           }
         },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
           "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
           "bundled": true,
           "dev": true
         },
@@ -994,21 +1395,239 @@
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
-            "strip-bom": {
-              "version": "2.0.0",
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-utf8": "^0.2.0"
-              },
-              "dependencies": {
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -1021,747 +1640,519 @@
             "commondir": "^1.0.1",
             "mkdirp": "^0.5.1",
             "pkg-dir": "^1.0.0"
-          },
-          "dependencies": {
-            "commondir": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "^1.0.0"
-              }
-            }
           }
         },
         "find-up": {
-          "version": "1.1.2",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pinkie": "^2.0.0"
-              },
-              "dependencies": {
-                "pinkie": {
-                  "version": "2.0.4",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
+            "locate-path": "^2.0.0"
           }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
         },
         "foreground-child": {
-          "version": "1.5.1",
+          "version": "1.5.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn-async": "^2.1.1",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.1"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
-            "cross-spawn-async": {
-              "version": "2.2.4",
+            "source-map": {
+              "version": "0.4.4",
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.0",
-                "which": "^1.2.8"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "pseudomap": "^1.0.1",
-                    "yallist": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "pseudomap": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "yallist": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "signal-exit": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "which": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
+                "amdefine": ">=0.0.4"
               }
             }
           }
         },
-        "glob": {
-          "version": "7.0.3",
+        "has-ansi": {
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
-            "inflight": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
+            "isobject": {
+              "version": "3.0.1",
               "bundled": true,
               "dev": true
-            },
-            "minimatch": {
+            }
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
               "version": "3.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.0.0"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.4",
+                "kind-of": {
+                  "version": "3.2.2",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^0.4.1",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
             },
-            "once": {
-              "version": "1.3.3",
+            "kind-of": {
+              "version": "4.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
+                "is-buffer": "^1.1.5"
               }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
               "bundled": true,
               "dev": true
             }
           }
         },
-        "istanbul": {
-          "version": "0.4.3",
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.0.x",
-            "async": "1.x",
-            "escodegen": "1.8.x",
-            "esprima": "2.7.x",
-            "fileset": "0.2.x",
-            "handlebars": "^4.0.1",
-            "js-yaml": "3.x",
-            "mkdirp": "0.5.x",
-            "nopt": "3.x",
-            "once": "1.x",
-            "resolve": "1.1.x",
-            "supports-color": "^3.1.0",
-            "which": "^1.1.1",
-            "wordwrap": "^1.0.0"
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^4.0.0"
           },
           "dependencies": {
-            "abbrev": {
-              "version": "1.0.7",
+            "is-number": {
+              "version": "4.0.0",
               "bundled": true,
               "dev": true
-            },
-            "async": {
-              "version": "1.5.2",
+            }
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
               "bundled": true,
               "dev": true
-            },
-            "escodegen": {
-              "version": "1.8.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "esprima": "^2.7.1",
-                "estraverse": "^1.9.1",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.2.0"
-              },
-              "dependencies": {
-                "estraverse": {
-                  "version": "1.9.3",
-                  "bundled": true,
-                  "dev": true
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "optionator": {
-                  "version": "0.8.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "deep-is": "~0.1.3",
-                    "fast-levenshtein": "^1.1.0",
-                    "levn": "~0.3.0",
-                    "prelude-ls": "~1.1.2",
-                    "type-check": "~0.3.2",
-                    "wordwrap": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "deep-is": {
-                      "version": "0.1.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "fast-levenshtein": {
-                      "version": "1.1.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "levn": {
-                      "version": "0.3.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                      }
-                    },
-                    "prelude-ls": {
-                      "version": "1.1.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "type-check": {
-                      "version": "0.3.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "prelude-ls": "~1.1.2"
-                      }
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "amdefine": ">=0.0.4"
-                  },
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "bundled": true,
-              "dev": true
-            },
-            "fileset": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "5.x",
-                "minimatch": "2.x"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "^0.4.1",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.1",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "handlebars": {
-              "version": "4.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "async": "^1.4.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.4.4",
-                "uglify-js": "^2.6"
-              },
-              "dependencies": {
-                "optimist": {
-                  "version": "0.6.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "minimist": "~0.0.1",
-                    "wordwrap": "~0.0.2"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.10",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "amdefine": ">=0.0.4"
-                  },
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "uglify-js": {
-                  "version": "2.6.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "async": "~0.2.6",
-                    "source-map": "~0.5.1",
-                    "uglify-to-browserify": "~1.0.0",
-                    "yargs": "~3.10.0"
-                  },
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    },
-                    "source-map": {
-                      "version": "0.5.6",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    },
-                    "uglify-to-browserify": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    },
-                    "yargs": {
-                      "version": "3.10.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
-                        "window-size": "0.1.0"
-                      },
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "center-align": "^0.1.1",
-                            "right-align": "^0.1.1",
-                            "wordwrap": "0.0.2"
-                          },
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.3",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "align-text": "^0.1.3",
-                                "lazy-cache": "^1.0.3"
-                              },
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.3",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true,
-                                      "requires": {
-                                        "is-buffer": "^1.0.2"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3",
-                                          "bundled": true,
-                                          "dev": true,
-                                          "optional": true
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "align-text": "^0.1.1"
-                              },
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.3",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true,
-                                      "requires": {
-                                        "is-buffer": "^1.0.2"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3",
-                                          "bundled": true,
-                                          "dev": true,
-                                          "optional": true
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4",
-                                      "bundled": true,
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        },
-                        "window-size": {
-                          "version": "0.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.6.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
-              },
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "sprintf-js": "~1.0.2"
-                  },
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "abbrev": "1"
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.7",
-              "bundled": true,
-              "dev": true
-            },
+            }
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "^0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
+          "dependencies": {
             "supports-color": {
-              "version": "3.1.2",
+              "version": "3.2.3",
               "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
-              },
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
               }
-            },
-            "which": {
-              "version": "1.2.10",
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
+                "ms": "2.0.0"
               }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
               "bundled": true,
               "dev": true
             }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-visit": "^1.0.0"
           }
         },
         "md5-hex": {
@@ -1770,289 +2161,96 @@
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
           },
           "dependencies": {
-            "md5-o-matic": {
-              "version": "0.1.1",
+            "source-map": {
+              "version": "0.6.1",
               "bundled": true,
               "dev": true
             }
           }
         },
         "micromatch": {
-          "version": "2.3.8",
+          "version": "3.1.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           },
           "dependencies": {
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.0.1"
-              },
-              "dependencies": {
-                "arr-flatten": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
-              },
-              "dependencies": {
-                "expand-range": {
-                  "version": "1.8.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "fill-range": "^2.1.0"
-                  },
-                  "dependencies": {
-                    "fill-range": {
-                      "version": "2.2.3",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^1.1.3",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                      },
-                      "dependencies": {
-                        "is-number": {
-                          "version": "2.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "kind-of": "^3.0.2"
-                          }
-                        },
-                        "isobject": {
-                          "version": "2.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "isarray": "1.0.0"
-                          },
-                          "dependencies": {
-                            "isarray": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "randomatic": {
-                          "version": "1.1.5",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-number": "^2.0.2",
-                            "kind-of": "^3.0.2"
-                          }
-                        },
-                        "repeat-string": {
-                          "version": "1.5.4",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "preserve": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "repeat-element": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-posix-bracket": "^0.1.0"
-              },
-              "dependencies": {
-                "is-posix-bracket": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
             "kind-of": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.0.2"
-              },
-              "dependencies": {
-                "is-buffer": {
-                  "version": "1.1.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "normalize-path": {
-              "version": "2.0.1",
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
-            },
-            "object.omit": {
-              "version": "2.0.0",
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
               "bundled": true,
               "dev": true,
               "requires": {
-                "for-own": "^0.1.3",
-                "is-extendable": "^0.1.1"
-              },
-              "dependencies": {
-                "for-own": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "for-in": "^0.1.5"
-                  },
-                  "dependencies": {
-                    "for-in": {
-                      "version": "0.1.5",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "is-extendable": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-              },
-              "dependencies": {
-                "glob-base": {
-                  "version": "0.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "glob-parent": "^2.0.0",
-                    "is-glob": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "glob-parent": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-glob": "^2.0.0"
-                      }
-                    }
-                  }
-                },
-                "is-dotfile": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-equal-shallow": "^0.1.3",
-                "is-primitive": "^2.0.0"
-              },
-              "dependencies": {
-                "is-equal-shallow": {
-                  "version": "0.1.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-primitive": "^2.0.0"
-                  }
-                },
-                "is-primitive": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -2063,879 +2261,1272 @@
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
           }
         },
-        "pkg-up": {
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
           }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
         "rimraf": {
-          "version": "2.5.2",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.0"
+            "glob": "^7.0.5"
           }
         },
-        "signal-exit": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "^1.3.3",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.3.3",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.4"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "which": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "test-exclude": {
+        "safe-regex": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "lodash.assign": "^4.0.9",
-            "micromatch": "^2.3.8",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
+            "ret": "~0.1.10"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
-            "lodash.assign": {
-              "version": "4.0.9",
+            "extend-shallow": {
+              "version": "2.0.1",
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
-              },
-              "dependencies": {
-                "lodash.keys": {
-                  "version": "4.0.7",
-                  "bundled": true,
-                  "dev": true
-                },
-                "lodash.rest": {
-                  "version": "4.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
+                "is-extendable": "^0.1.0"
               }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
               "bundled": true,
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
-              },
-              "dependencies": {
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "error-ex": "^1.2.0"
-                          },
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "is-arrayish": "^0.2.1"
-                              },
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-utf8": "^0.2.0"
-                          },
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
-                      },
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.5",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-builtin-module": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "builtin-modules": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "builtin-modules": {
-                              "version": "1.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "semver": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "validate-npm-package-license": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
-                          },
-                          "dependencies": {
-                            "spdx-correct": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-license-ids": "^1.0.2"
-                              },
-                              "dependencies": {
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "spdx-expression-parse": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "spdx-exceptions": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+                "is-descriptor": "^0.1.0"
               }
             },
-            "require-main-filename": {
-              "version": "1.0.1",
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
           }
         },
-        "yargs": {
-          "version": "4.7.1",
+        "snapdragon-util": {
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
+            "kind-of": "^3.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
-            "camelcase": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
               "version": "3.0.0",
               "bundled": true,
               "dev": true
             },
-            "cliui": {
-              "version": "3.2.0",
+            "strip-ansi": {
+              "version": "4.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "wrap-ansi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "string-width": "^1.0.1"
-                  }
-                }
+                "ansi-regex": "^3.0.0"
               }
-            },
-            "decamelize": {
-              "version": "1.2.0",
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
               "bundled": true,
               "dev": true
             },
-            "lodash.assign": {
-              "version": "4.0.9",
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
-                "lodash.keys": {
-                  "version": "4.0.7",
+                "extend-shallow": {
+                  "version": "2.0.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
                 },
-                "lodash.rest": {
-                  "version": "4.0.3",
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
                   "bundled": true,
                   "dev": true
                 }
               }
             },
-            "os-locale": {
-              "version": "1.4.0",
+            "extglob": {
+              "version": "2.0.4",
               "bundled": true,
               "dev": true,
               "requires": {
-                "lcid": "^1.0.0"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
-                "lcid": {
+                "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "invert-kv": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "invert-kv": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
+                    "is-descriptor": "^1.0.0"
                   }
-                }
-              }
-            },
-            "pkg-conf": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "^1.0.0",
-                "load-json-file": "^1.1.0",
-                "object-assign": "^4.0.1",
-                "symbol": "^0.2.1"
-              },
-              "dependencies": {
-                "load-json-file": {
-                  "version": "1.1.0",
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "parse-json": "^2.2.0",
-                    "pify": "^2.0.0",
-                    "pinkie-promise": "^2.0.0",
-                    "strip-bom": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.4",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "parse-json": {
-                      "version": "2.2.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "error-ex": "^1.2.0"
-                      },
-                      "dependencies": {
-                        "error-ex": {
-                          "version": "1.3.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-arrayish": "^0.2.1"
-                          },
-                          "dependencies": {
-                            "is-arrayish": {
-                              "version": "0.2.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "pinkie": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "strip-bom": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-utf8": "^0.2.0"
-                      },
-                      "dependencies": {
-                        "is-utf8": {
-                          "version": "0.2.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
+                    "is-extendable": "^0.1.0"
                   }
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "symbol": {
-                  "version": "0.2.3",
-                  "bundled": true,
-                  "dev": true
                 }
               }
             },
-            "read-pkg-up": {
-              "version": "1.0.1",
+            "fill-range": {
+              "version": "4.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
               },
               "dependencies": {
-                "read-pkg": {
-                  "version": "1.1.0",
+                "extend-shallow": {
+                  "version": "2.0.1",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "error-ex": "^1.2.0"
-                          },
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "is-arrayish": "^0.2.1"
-                              },
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "is-utf8": "^0.2.0"
-                          },
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
-                      },
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.5",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-builtin-module": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "builtin-modules": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "builtin-modules": {
-                              "version": "1.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "semver": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "validate-npm-package-license": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
-                          },
-                          "dependencies": {
-                            "spdx-correct": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-license-ids": "^1.0.2"
-                              },
-                              "dependencies": {
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "spdx-expression-parse": {
-                              "version": "1.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "spdx-exceptions": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "spdx-license-ids": {
-                                  "version": "1.2.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.4",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
             },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "set-blocking": {
+            "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
               "dev": true
             },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            }
+          }
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
             "string-width": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
               }
-            },
-            "window-size": {
-              "version": "0.2.0",
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
               "bundled": true,
               "dev": true
             },
-            "y18n": {
-              "version": "3.2.1",
+            "camelcase": {
+              "version": "4.1.0",
               "bundled": true,
               "dev": true
             },
-            "yargs-parser": {
-              "version": "2.4.0",
+            "cliui": {
+              "version": "4.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "^2.1.1",
-                "lodash.assign": "^4.0.6"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
               }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "9.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "http-server": "^0.11.1",
     "jshint": "^2.9.2",
     "mocha": "^5.2.0",
-    "nyc": "^6.6.1"
+    "nyc": "^11.0.0"
   },
   "directories": {
     "doc": "doc"


### PR DESCRIPTION
This fixes security issues. I chose the same version we use for shx.