### PR TITLE
chore(coverage): properly configure nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "posttest": "npm run lint",
     "deploy": "deploy-gh"
   },
+  "nyc": {
+    "exclude": [
+      "lib/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nfischer/rainbows-lang.git"

--- a/test/test.js
+++ b/test/test.js
@@ -29,8 +29,7 @@ s.addOperation('rb()', interp.rbInterp);
 
 var logOutput;
 
-function doTest(expr, type, val, setup) {
-  if (setup) setup();
+function doTest(expr, type, val) {
   var m = es5.match(expr);
   assert.ok(m.succeeded());
   assert.strictEqual(s(m).ti(), type);


### PR DESCRIPTION
This configures nyc to ignore the 'lib/' folder, as these are all
dependencies which don't need to be covered by this project's tests.

This also removes a 'setup' parameter in the tests, since this was
unused (and nyc was complaining).