### PR TITLE
refactor: create a small wrapper module for ohm

### DIFF
--- a/bin/rbInstance.js
+++ b/bin/rbInstance.js
@@ -1,4 +1,4 @@
-var ohm = require('../lib/ohm/dist/ohm');
+var ohm = require('../src/ohm');
 var inference = require('../src/inference');
 var interp = require('../src/interp');
 var fs = require('fs');

--- a/src/ohm.js
+++ b/src/ohm.js
@@ -1,0 +1,12 @@
+// This is a thin wrapper over the ohm submodule so that we can throw an error
+// if the submodule is missing.
+var colors = require('colors/safe');
+try {
+  module.exports = require('../lib/ohm/dist/ohm');
+} catch (e) {
+  console.error(colors.bold.red(
+      'Cannot find lib/ohm/dist/ohm; did you forget to pull submodules?\n'));
+  console.error(colors.bold.yellow(
+      '  git submodule update --init --recursive\n'));
+  process.exit(1);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ require('shelljs/global');
 var assert = require('assert');
 /* istanbul ignore next */
 try {
-  var ohm = require('../lib/ohm/dist/ohm');
+  var ohm = require('../src/ohm');
 } catch (e) {
   console.error(e);
   console.error();


### PR DESCRIPTION
This moves ohm into a tiny wrapper module and prints an error message if
the git submodule hasn't been downloaded.