### PR TITLE
chore: rename branch master -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Rainbows :rainbow:
 A prototype of the Rainbows programming language
 
-[![Travis](https://img.shields.io/travis/nfischer/rainbows-lang/master.svg?style=flat-square)](https://travis-ci.org/nfischer/rainbows-lang)
-[![Codecov](https://img.shields.io/codecov/c/github/nfischer/rainbows-lang/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/nfischer/rainbows-lang)
+[![Travis](https://img.shields.io/travis/nfischer/rainbows-lang/main.svg?style=flat-square)](https://travis-ci.org/nfischer/rainbows-lang)
+[![Codecov](https://img.shields.io/codecov/c/github/nfischer/rainbows-lang/main.svg?style=flat-square&label=coverage)](https://codecov.io/gh/nfischer/rainbows-lang)
 [![Try online](https://img.shields.io/badge/try_it-online!-yellow.svg?style=flat-square)](https://nfischer.github.io/rainbows-lang/)
 
 *Because coding should be as easy as coloring in the lines, and programs should

--- a/src/rainbows.ohm
+++ b/src/rainbows.ohm
@@ -1,6 +1,6 @@
 /*
   This grammar was based on the Ohm grammar for ES5 found at
-  https://github.com/cdglabs/ohm/blob/master/examples/ecmascript/es5.ohm
+  https://github.com/harc/ohm/blob/master/examples/ecmascript/src/es5.ohm
 
   Here's the license in that file:
 */


### PR DESCRIPTION
This updates URLs in the README to use the new branch name. This also
updates one other URL which I noticed was broken.