### PR TITLE
chore: remove codecov devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "rain-interp.js": "bin/rain-interp.js"
   },
   "scripts": {
-    "codecov": "codecov",
     "start": "http-server -o",
     "test": "nyc --reporter=text --reporter=lcov mocha",
     "lint": "jshint src test bin",


### PR DESCRIPTION
No change to logic. This removes the codecov package dependency because
this is provided through GitHub Actions now.