### PR TITLE
chore: bump min node version: v6->v10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 6
-          - 8
           - 10
           - 12
           - 14

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "doc": "doc"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
This drops support for node v6 and v8.