### PR TITLE
docs: change GitHub Actions README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Rainbows :rainbow:
+
 A prototype of the Rainbows programming language
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fnfischer%2Frainbows-lang%2Fbadge%3Fref%3Dmain&style=flat-square)](https://actions-badge.atrox.dev/nfischer/rainbows-lang/goto?ref=main)
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/nfischer/rainbows-lang/main.yml?style=flat-square&logo=github)](https://github.com/nfischer/rainbows-lang/actions/workflows/main.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/nfischer/rainbows-lang/main.svg?style=flat-square&label=coverage)](https://codecov.io/gh/nfischer/rainbows-lang)
 [![Try online](https://img.shields.io/badge/try_it-online!-yellow.svg?style=flat-square)](https://nfischer.github.io/rainbows-lang/)
 


### PR DESCRIPTION
This changes the README to use a standard shields.io badge for GitHub Actions. The custom badge
(https://github.com/Atrox/github-actions-badge) was cool, but the atrox.dev link doesn't work reliably. I noticed that shields has support for this now, so there's no reason to use a custom badge.

One notably difference is that this badge says the build is passing even if there's a job still in progress.