### PR TITLE
chore: drop unsupported node versions on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,20 @@ jobs:
           - 12
           - 14
           - 16
+          - 18
+          - 20
+          - 22
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        exclude:
+          - node-version: 10
+            os: macos-latest
+          - node-version: 12
+            os: macos-latest
+          - node-version: 14
+            os: macos-latest
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2


### PR DESCRIPTION
No change to logic. This drops support for older NodeJS versions on macOS because GitHub Actions no longer supports them.

This also updates NodeJS to the latest LTS release.